### PR TITLE
Added "auto message removal" feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+config.yaml
+.env

--- a/ModLogBot.py
+++ b/ModLogBot.py
@@ -16,6 +16,8 @@ from discord.app_commands import Choice
 from discord.ext import commands
 from sqlalchemy import create_engine, Column, Integer, DateTime, func, JSON, BLOB
 from sqlalchemy.orm import sessionmaker, declarative_base
+import re
+from pydantic import BaseModel
 
 BUILD_DATE = os.getenv('BUILD_DATE', None)
 VERSION = os.getenv('VERSION', None)
@@ -52,6 +54,13 @@ need_reason = [
     ActionType.TIMEOUT
 ]
 
+class Config_AutoMessageRemoval(BaseModel):
+    channel_id: int
+    regex_matching: Optional[str] = None
+    regex_not_matching: Optional[str] = None
+    removal_delay_seconds: Optional[float] = None
+    response_message: Optional[str] = None
+
 config_folder_path = os.environ.get("CONFIG_FOLDER_PATH", "/config/")
 
 # Database setup
@@ -79,7 +88,7 @@ if BOT_TOKEN is None:
     except KeyError:
         pass
 if BOT_TOKEN is None:
-    raise ValueError("BOT_TOKEN is not set in config.yml or environment variables.")
+    raise ValueError("BOT_TOKEN is not set in environment variables, and bot->token not found in config.yml.")
 
 def load_servers():
     servers = {}
@@ -117,13 +126,19 @@ def load_servers():
                         ignored_channels.append(int(ignored_channel))
                     except (ValueError, TypeError):
                         print(f"Ignored Channel ID `{ignored_channel}` is not a valid channel ID. Skipping channel.")
+            
+            auto_message_removals = []
+            if "auto_message_removals" in config["servers"][server]:
+                for auto_message_removal in config["servers"][server]["auto_message_removals"]:
+                    auto_message_removals.append(Config_AutoMessageRemoval(**auto_message_removal))
 
             servers[server_id] = {
                 "name": server,
                 "log_channel_id": log_channel_id,
                 "report_channel_id": report_channel_id,
                 "report_role_ping_id": report_role_ping_id,
-                "ignored_channels": ignored_channels
+                "ignored_channels": ignored_channels,
+                "auto_message_removals": auto_message_removals,
             }
     return servers
 SERVERS = None
@@ -263,6 +278,15 @@ def get_ignored_channels(server_id: int):
         return get_server(server_id)['ignored_channels']
     except KeyError:
         print(f"Ignored channel not found for server {server_id}")
+        return []
+    except TypeError:
+        return []
+
+def get_auto_message_removals(server_id: int) -> List[Config_AutoMessageRemoval]:
+    try:
+        return get_server(server_id)['auto_message_removals']
+    except KeyError:
+        # No debug log if not found
         return []
     except TypeError:
         return []
@@ -454,8 +478,31 @@ async def handle_dm(message):
     print(f"Received DM from {message.author.name}: {message.content}")
     await message.reply("Thank you for your message! Please use the `/report` command to report issues", mention_author=False)
 
-async def handle_guild_message(message):
-    pass
+async def handle_guild_message(message: discord.Message):
+    # Don't fuck with other bots
+    if message.author.bot:
+        return
+    
+    # Process auto message removal channels
+    auto_message_removals = get_auto_message_removals(message.guild.id)
+    for auto_message_removal in auto_message_removals:
+        if message.channel.id == auto_message_removal.channel_id:
+            # Test the regex_matching test
+            if auto_message_removal.regex_matching is not None and re.match(auto_message_removal.regex_matching, message.content) is None:
+                continue # setting is set and NOT matched, so we proceed to next channel
+
+            # Test the regex_not_matching test
+            if auto_message_removal.regex_not_matching is not None and re.match(auto_message_removal.regex_not_matching, message.content) is not None:
+                continue # setting is set and matched, so we proceed to next channel
+
+            # At this point, channel was matched and conditionals were validated
+            if auto_message_removal.response_message:
+                # Send a response that deletes itself after the configured time
+                msg = await message.reply(auto_message_removal.response_message, mention_author=True)
+                await msg.delete(delay=auto_message_removal.removal_delay_seconds)
+
+            # Delete the user's original message after the configured time
+            await message.delete(delay=auto_message_removal.removal_delay_seconds)
 
 @bot.command()
 # @commands.guild_only()

--- a/config.example.yml
+++ b/config.example.yml
@@ -12,7 +12,17 @@ servers:
         ignored_channels:
             - # List of channel IDs to ignore, e.g., 123456789012345678
             - # Another channel ID to ignore
-
+        auto_message_removals:
+            - channel_id: # Required integer: Channel ID to monitor for new messages to remove
+              regex_matching: # Optional string: RegEx pattern to match against posted message; if both regex tests pass, message will be removed
+              regex_not_matching: # Optional string: RegEx pattern to NOT match against posted message; if both regex tests pass, message will be removed
+              removal_delay_seconds: # Optional float: Number of seconds to wait before deleting the original message and the optional response
+              response_message: # Optional string: Message to post in response to message posted to channel
+            - channel_id: # ...
+              regex_matching: # ...
+              regex_not_matching: # ...
+              removal_delay_seconds: # ...
+              response_message: # ...
     server_2:
         id: # Your server ID here
         log_channel_id: # Your server log channel ID here


### PR DESCRIPTION
Added a new feature to automatically remove messages crom configured channels. Posted message is tested against a positive and negative RegEx match. If both tests pass, the message is removed.

Change can have an optional response to the user, and can delay the removal of the message (and response) for a configurable amount of time.

This is to clean up the "#join-role-member" channel when someone posts a message that does not match the "!join-role" command. Prevents conversation in that channel.